### PR TITLE
updated conftest to use uuid for user response data id field

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -251,7 +251,7 @@ def user_update_data():
 @pytest.fixture
 def user_response_data():
     return {
-        "id": "unique-id-string",
+        "id": uuid4(),
         "username": "testuser",
         "email": "test@example.com",
         "last_login_at": datetime.now(),


### PR DESCRIPTION
the user_response_data fixture was not creating a valid user.id because it was passing a random string instead of a UUID. I updated the fixture to now pass in a valid uuid